### PR TITLE
fixes bug in view where elixir_interpolation.unescape_chars was privatized

### DIFF
--- a/lib/kalevala/character/view.ex
+++ b/lib/kalevala/character/view.ex
@@ -80,7 +80,7 @@ defmodule Kalevala.Character.View.Macro do
   end
 
   defp sigil_i_unwrap(text) when is_binary(text) do
-    :elixir_interpolation.unescape_chars(text)
+    :elixir_interpolation.unescape_string(text)
   end
 end
 


### PR DESCRIPTION
this commit broke the things for 1.12 

https://github.com/elixir-lang/elixir/commit/7d3a33698008e800a2bc3031c80e1c6f19b2e79a#diff-8459fda1a6be2648729f053b9380160826e30b4cc79da7f965b302fee5cf6916

I'm not sure how you want to handle backwards compatibility here.