### PR TITLE
Room.Context.put_data() - allow data updates from Room.Events

### DIFF
--- a/lib/kalevala/cache.ex
+++ b/lib/kalevala/cache.ex
@@ -73,6 +73,13 @@ defmodule Kalevala.Cache do
       end
 
       @doc """
+      Delete a value from the cache
+      """
+      def delete(key) do
+        Kalevala.Cache.delete(__MODULE__, key)
+      end
+
+      @doc """
       Get a value from the cache
 
       Unwraps the tagged tuple, returns the direct value. Raises an error
@@ -116,6 +123,13 @@ defmodule Kalevala.Cache do
       _ ->
         {:error, :not_found}
     end
+  end
+
+  @doc """
+  Delete a value from the cache
+  """
+  def delete(name, key) do
+    :ets.delete(name, key)
   end
 
   @doc """

--- a/lib/kalevala/character/action.ex
+++ b/lib/kalevala/character/action.ex
@@ -6,7 +6,7 @@ defmodule Kalevala.Character.Action do
   flee in a random direction.
   """
 
-  @callback run(Conn.t(), map()) :: :ok
+  @callback run(Conn.t(), map()) :: Conn.t()
 
   defstruct [:request_id, :type, delay: 0, params: %{}]
 

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -307,9 +307,9 @@ defmodule Kalevala.Character.Conn do
   @doc """
   Creates an even to move from one room to another
   """
-  def move(conn, direction, room_id, view, template, assigns) do
-    assigns = merge_assigns(conn, assigns)
-    data = view.render(template, assigns)
+  def move(conn, direction, room_id, view, template, data) do
+    assigns = merge_assigns(conn, data)
+    render = view.render(template, assigns)
 
     event = %Kalevala.Event{
       acting_character: Private.character(conn),
@@ -318,7 +318,8 @@ defmodule Kalevala.Character.Conn do
       data: %Kalevala.Event.Movement{
         character: Private.character(conn),
         direction: direction,
-        reason: data,
+        reason: render,
+        data: data,
         room_id: room_id
       }
     }

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -160,9 +160,8 @@ defmodule Kalevala.Character.Conn do
   end
 
   defp merge_assigns(conn, assigns) do
-    conn.session
+    Map.new()
     |> Map.put(:character, Private.character(conn))
-    |> Map.merge(conn.flash)
     |> Map.merge(conn.assigns)
     |> Map.merge(assigns)
   end
@@ -308,8 +307,8 @@ defmodule Kalevala.Character.Conn do
   @doc """
   Creates an even to move from one room to another
   """
-  def move(conn, direction, room_id, view, template, assigns \\ %{}) do
-    assigns = Map.merge(conn.assigns, assigns)
+  def move(conn, direction, room_id, view, template, data \\ %{}) do
+    assigns = Map.merge(conn.assigns, data)
     reason = view.render(template, assigns)
 
     event = %Kalevala.Event{
@@ -321,7 +320,7 @@ defmodule Kalevala.Character.Conn do
         direction: direction,
         reason: reason,
         room_id: room_id,
-        data: assigns
+        data: data
       }
     }
 

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -182,7 +182,7 @@ defmodule Kalevala.Character.Conn do
   Render text to the conn
   """
   def render(conn, view, template, assigns \\ %{}) do
-    assigns = merge_assigns(conn, assigns)
+    assigns = merge_assigns(conn.ai, assigns)
     data = view.render(template, assigns)
     push(conn, data, false)
   end
@@ -308,10 +308,9 @@ defmodule Kalevala.Character.Conn do
   @doc """
   Creates an even to move from one room to another
   """
-  def move(conn, direction, room_id, view, template, assigns) do
-    assigns = merge_assigns(conn, assigns)
+  def move(conn, direction, room_id, view, template, assigns \\ %{}) do
+    assigns = Map.merge(conn.assigns, assigns)
     reason = view.render(template, assigns)
-    data = assigns || %{}
 
     event = %Kalevala.Event{
       acting_character: Private.character(conn),
@@ -322,7 +321,7 @@ defmodule Kalevala.Character.Conn do
         direction: direction,
         reason: reason,
         room_id: room_id,
-        data: data
+        data: assigns
       }
     }
 

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -309,7 +309,8 @@ defmodule Kalevala.Character.Conn do
   """
   def move(conn, direction, room_id, view, template, assigns) do
     assigns = merge_assigns(conn, assigns)
-    data = view.render(template, assigns)
+    reason = view.render(template, assigns)
+    data = assigns || %{}
 
     event = %Kalevala.Event{
       acting_character: Private.character(conn),
@@ -318,9 +319,9 @@ defmodule Kalevala.Character.Conn do
       data: %Kalevala.Event.Movement{
         character: Private.character(conn),
         direction: direction,
-        reason: data,
+        reason: reason,
         room_id: room_id,
-        data: assigns
+        data: data
       }
     }
 

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -161,7 +161,7 @@ defmodule Kalevala.Character.Conn do
 
   defp merge_assigns(conn, assigns) do
     Map.new()
-    |> Map.put(:character, Private.character(conn))
+    |> Map.put(:self, Private.character(conn))
     |> Map.merge(conn.assigns)
     |> Map.merge(assigns)
   end
@@ -308,6 +308,7 @@ defmodule Kalevala.Character.Conn do
   Creates an even to move from one room to another
   """
   def move(conn, direction, room_id, view, template, data \\ %{}) do
+    data = Map.put(data, :character, Private.character(conn))
     assigns = merge_assigns(conn, data)
 
     reason = view.render(template, assigns)

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -116,6 +116,7 @@ defmodule Kalevala.Character.Conn do
   alias Kalevala.Meta
 
   defstruct [
+    :controller,
     :character,
     :params,
     assigns: %{},

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -94,7 +94,7 @@ defmodule Kalevala.Character.Conn.Text do
   new text.
   """
 
-  defstruct [:data, newline: false, go_ahead: false]
+  defstruct [:data, newline: false, go_ahead: true]
 end
 
 defmodule Kalevala.Character.Conn.Option do

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -308,7 +308,7 @@ defmodule Kalevala.Character.Conn do
   Creates an even to move from one room to another
   """
   def move(conn, direction, room_id, view, template, data) do
-    assigns = merge_assigns(conn, data)
+    assigns = merge_assigns(conn, %{})
     render = view.render(template, assigns)
 
     event = %Kalevala.Event{

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -319,7 +319,8 @@ defmodule Kalevala.Character.Conn do
         character: Private.character(conn),
         direction: direction,
         reason: data,
-        room_id: room_id
+        room_id: room_id,
+        data: assigns
       }
     }
 

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -181,7 +181,7 @@ defmodule Kalevala.Character.Conn do
   Render text to the conn
   """
   def render(conn, view, template, assigns \\ %{}) do
-    assigns = merge_assigns(conn.ai, assigns)
+    assigns = merge_assigns(conn, assigns)
     data = view.render(template, assigns)
     push(conn, data, false)
   end
@@ -308,7 +308,8 @@ defmodule Kalevala.Character.Conn do
   Creates an even to move from one room to another
   """
   def move(conn, direction, room_id, view, template, data \\ %{}) do
-    assigns = Map.merge(conn.assigns, data)
+    assigns = merge_assigns(conn, data)
+
     reason = view.render(template, assigns)
 
     event = %Kalevala.Event{

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -307,9 +307,9 @@ defmodule Kalevala.Character.Conn do
   @doc """
   Creates an even to move from one room to another
   """
-  def move(conn, direction, room_id, view, template, data) do
-    assigns = merge_assigns(conn, %{})
-    render = view.render(template, assigns)
+  def move(conn, direction, room_id, view, template, assigns) do
+    assigns = merge_assigns(conn, assigns)
+    data = view.render(template, assigns)
 
     event = %Kalevala.Event{
       acting_character: Private.character(conn),
@@ -318,8 +318,7 @@ defmodule Kalevala.Character.Conn do
       data: %Kalevala.Event.Movement{
         character: Private.character(conn),
         direction: direction,
-        reason: render,
-        data: data,
+        reason: data,
         room_id: room_id
       }
     }

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -162,8 +162,8 @@ defmodule Kalevala.Character.Conn do
   defp merge_assigns(conn, assigns) do
     conn.session
     |> Map.put(:character, Private.character(conn))
-    |> Map.merge(conn.assigns)
     |> Map.merge(conn.flash)
+    |> Map.merge(conn.assigns)
     |> Map.merge(assigns)
   end
 

--- a/lib/kalevala/character/conn.ex
+++ b/lib/kalevala/character/conn.ex
@@ -449,6 +449,14 @@ defmodule Kalevala.Character.Conn do
     put_character(conn, character)
   end
 
+  @doc """
+  Get values in a character's meta map
+  """
+  def get_meta(conn, key) do
+    character = character(conn)
+    Meta.get(character.meta, key)
+  end
+
   defp put_private(conn, key, value) do
     private = Map.put(conn.private, key, value)
     Map.put(conn, :private, private)

--- a/lib/kalevala/character/foreman.ex
+++ b/lib/kalevala/character/foreman.ex
@@ -73,6 +73,7 @@ defmodule Kalevala.Character.Foreman do
   @doc false
   def new_conn(state) do
     %Conn{
+      controller: state.controller,
       character: state.character,
       session: state.session,
       flash: state.flash,

--- a/lib/kalevala/communication.ex
+++ b/lib/kalevala/communication.ex
@@ -106,7 +106,7 @@ defmodule Kalevala.Communication do
         Channel.subscribe(pid, channel_name, subscriber_pid, options)
 
       _ ->
-        :error
+        {:error, :channel_not_found}
     end
   end
 
@@ -119,7 +119,7 @@ defmodule Kalevala.Communication do
         Channel.unsubscribe(pid, channel_name, subscriber_pid, options)
 
       _ ->
-        :error
+        {:error, :channel_not_found}
     end
   end
 
@@ -142,6 +142,6 @@ defmodule Kalevala.Communication do
     Only events with a topic of #{__MODULE__} allowed.
     """)
 
-    :error
+    {:error, :channel_not_found}
   end
 end

--- a/lib/kalevala/event/movement.ex
+++ b/lib/kalevala/event/movement.ex
@@ -30,7 +30,7 @@ defmodule Kalevala.Event.Movement.Commit do
   Struct for committing movement between two rooms
   """
 
-  defstruct [:character, :to, :from, :exit_name]
+  defstruct [:character, :to, :from, :exit_name, :entrance_name]
 end
 
 defmodule Kalevala.Event.Movement.Abort do
@@ -57,6 +57,7 @@ defmodule Kalevala.Event.Movement.Voting do
     :to,
     :from,
     :exit_name,
+    :entrance_name,
     :reason,
     aborted: false
   ]
@@ -86,7 +87,8 @@ defmodule Kalevala.Event.Movement.Voting do
         character: event.data.character,
         to: event.data.to,
         from: event.data.from,
-        exit_name: event.data.exit_name
+        exit_name: event.data.exit_name,
+        entrance_name: event.data.entrance_name
       }
     }
   end

--- a/lib/kalevala/event/movement.ex
+++ b/lib/kalevala/event/movement.ex
@@ -3,7 +3,7 @@ defmodule Kalevala.Event.Movement do
   An event to move from one room to another
   """
 
-  defstruct [:character, :direction, :reason, :room_id]
+  defstruct [:character, :direction, :reason, :room_id, :data]
 
   @typedoc """
   A movement event
@@ -22,7 +22,7 @@ defmodule Kalevala.Event.Movement.Notice do
   Event to send a notice to other characters in the room
   """
 
-  defstruct [:character, :direction, :reason]
+  defstruct [:character, :direction, :reason, :data]
 end
 
 defmodule Kalevala.Event.Movement.Commit do

--- a/lib/kalevala/world/room.ex
+++ b/lib/kalevala/world/room.ex
@@ -115,6 +115,10 @@ defmodule Kalevala.World.Room do
     {:reply, :ok, state}
   end
 
+  def handle_call(:dump, _from, state) do
+    {:reply, state, state}
+  end
+
   @impl true
   def handle_info(event = %Event{}, state) do
     Events.handle_event(event, state)
@@ -140,10 +144,6 @@ defmodule Kalevala.World.Room.Handler do
 
   def event(state, event) do
     Callbacks.event(state.data, Context.new(state), event)
-  end
-
-  def match_character?(character, keyword) do
-    Callbacks.match_character?(character, keyword)
   end
 
   # Items

--- a/lib/kalevala/world/room.ex
+++ b/lib/kalevala/world/room.ex
@@ -244,11 +244,6 @@ defprotocol Kalevala.World.Room.Callbacks do
   the exit.
   """
   def confirm_movement(room, context, event)
-
-  @doc """
-  Callback for matching a character with some criterion.
-  """
-  def match_character?(character, keyword)
 end
 
 defmodule Kalevala.World.BasicRoom do

--- a/lib/kalevala/world/room.ex
+++ b/lib/kalevala/world/room.ex
@@ -89,7 +89,8 @@ defmodule Kalevala.World.Room do
 
   @impl true
   def handle_continue(:initialized, state) do
-    Callbacks.initialized(state.data)
+    data = Callbacks.initialized(state.data)
+    state = %{state | data: data}
     {:noreply, state}
   end
 

--- a/lib/kalevala/world/room.ex
+++ b/lib/kalevala/world/room.ex
@@ -116,7 +116,7 @@ defmodule Kalevala.World.Room do
   end
 
   def handle_call(:dump, _from, state) do
-    {:reply, state, state}
+    {:reply, state.data, state}
   end
 
   @impl true

--- a/lib/kalevala/world/room.ex
+++ b/lib/kalevala/world/room.ex
@@ -142,6 +142,10 @@ defmodule Kalevala.World.Room.Handler do
     Callbacks.event(state.data, Context.new(state), event)
   end
 
+  def match_character?(characters, criterion) do
+    Callbacks.match_character?(characters, criterion)
+  end
+
   # Items
 
   def load_item(state, item_instance) do
@@ -240,6 +244,11 @@ defprotocol Kalevala.World.Room.Callbacks do
   the exit.
   """
   def confirm_movement(room, context, event)
+
+  @doc """
+  Callback for matching a character with some criterion.
+  """
+  def match_character?(characters, criterion)
 end
 
 defmodule Kalevala.World.BasicRoom do

--- a/lib/kalevala/world/room.ex
+++ b/lib/kalevala/world/room.ex
@@ -142,8 +142,8 @@ defmodule Kalevala.World.Room.Handler do
     Callbacks.event(state.data, Context.new(state), event)
   end
 
-  def match_character?(characters, criterion) do
-    Callbacks.match_character?(characters, criterion)
+  def match_character?(character, keyword) do
+    Callbacks.match_character?(character, keyword)
   end
 
   # Items
@@ -248,7 +248,7 @@ defprotocol Kalevala.World.Room.Callbacks do
   @doc """
   Callback for matching a character with some criterion.
   """
-  def match_character?(characters, criterion)
+  def match_character?(character, keyword)
 end
 
 defmodule Kalevala.World.BasicRoom do

--- a/lib/kalevala/world/room/context.ex
+++ b/lib/kalevala/world/room/context.ex
@@ -67,7 +67,7 @@ defmodule Kalevala.World.Room.Context do
   @doc """
   Render a prompt back to a pid
   """
-  def prompt(context, to_pid, view, template, assigns) do
+  def prompt(context, to_pid, view, template, assigns \\ %{}) do
     assigns = Map.merge(context.assigns, assigns)
     data = view.render(template, assigns)
     push(context, to_pid, data, true)

--- a/lib/kalevala/world/room/context.ex
+++ b/lib/kalevala/world/room/context.ex
@@ -107,7 +107,6 @@ defmodule Kalevala.World.Room.Context do
   Broadcast an event to multiple characters in the room
   Options:
     - `to`: pre-filtered list of characters
-    - `except`: keyword or list of keywords
   """
   def broadcast(context, topic, data, opts \\ []) do
     recipients = Keyword.get(opts, :to, context.characters)
@@ -116,20 +115,6 @@ defmodule Kalevala.World.Room.Context do
       case !is_list(recipients) do
         true -> List.wrap(recipients)
         false -> recipients
-      end
-
-    recipients =
-      case Keyword.get(opts, :except) do
-        nil ->
-          recipients
-
-        keywords when is_list(keywords) ->
-          Enum.reject(recipients, fn character ->
-            Enum.any?(keywords, &Handler.match_character?(character, &1))
-          end)
-
-        keyword ->
-          Enum.reject(recipients, &Handler.match_character?(&1, keyword))
       end
 
     Enum.reduce(recipients, context, fn character, acc ->

--- a/lib/kalevala/world/room/context.ex
+++ b/lib/kalevala/world/room/context.ex
@@ -114,13 +114,13 @@ defmodule Kalevala.World.Room.Context do
         nil ->
           recipients
 
-        criteria when is_list(criteria) ->
+        keywords when is_list(keywords) ->
           Enum.reject(recipients, fn character ->
-            Enum.any?(criteria, &Handler.match_character?(character, &1))
+            Enum.any?(keywords, &Handler.match_character?(character, &1))
           end)
 
-        criterion ->
-          Enum.reject(recipients, &Handler.match_character?(&1, criterion))
+        keyword ->
+          Enum.reject(recipients, &Handler.match_character?(&1, keyword))
       end
 
     Enum.reduce(recipients, context, fn character, acc ->

--- a/lib/kalevala/world/room/context.ex
+++ b/lib/kalevala/world/room/context.ex
@@ -95,21 +95,6 @@ defmodule Kalevala.World.Room.Context do
   end
 
   @doc """
-  Send an event to a pid on a delay
-  """
-
-  def delay_event(context, delay, to_pid, topic, data) do
-    event = %Kalevala.Event.Delayed{
-      delay: delay,
-      from_pid: self(),
-      topic: topic,
-      data: data
-    }
-
-    Map.put(context, :events, context.events ++ [{self(), event}])
-  end
-
-  @doc """
   Update the context data
   """
   def put_data(context, key, val) do
@@ -144,17 +129,8 @@ defmodule Kalevala.World.Room.Context do
   end
 
   defp send_events(context) do
-    {events, delayed_events} =
-      Enum.split_with(context.events, fn event ->
-        match?(%Kalevala.Event{}, event)
-      end)
-
-    Enum.each(events, fn {to_pid, event} ->
+    Enum.each(context.events, fn {to_pid, event} ->
       send(to_pid, event)
-    end)
-
-    Enum.each(delayed_events, fn {to_pid, delayed_event} ->
-      Process.send_after(to_pid, delayed_event, delayed_event.delay)
     end)
 
     context

--- a/lib/kalevala/world/room/context.ex
+++ b/lib/kalevala/world/room/context.ex
@@ -5,7 +5,6 @@ defmodule Kalevala.World.Room.Context do
 
   alias Kalevala.Event
   alias Kalevala.Meta
-  alias Kalevala.World.Room.Handler
 
   @type t() :: %__MODULE__{}
 
@@ -101,6 +100,18 @@ defmodule Kalevala.World.Room.Context do
   def put_data(context, key, val) do
     data = Map.put(context.data, key, val)
     Map.put(context, :data, data)
+  end
+
+  def update_character(context, character) do
+    %Kalevala.Character{id: id} = character
+
+    characters =
+      Enum.map(context.characters, fn
+        %{id: ^id} -> character
+        no_change -> no_change
+      end)
+
+    %{context | characters: characters}
   end
 
   @doc """

--- a/lib/kalevala/world/room/context.ex
+++ b/lib/kalevala/world/room/context.ex
@@ -95,6 +95,21 @@ defmodule Kalevala.World.Room.Context do
   end
 
   @doc """
+  Send an event to a pid on a delay
+  """
+
+  def delay_event(context, delay, to_pid, topic, data) do
+    event = %Kalevala.Event.Delayed{
+      delay: delay,
+      from_pid: self(),
+      topic: topic,
+      data: data
+    }
+
+    Map.put(context, :events, context.events ++ [{self(), event}])
+  end
+
+  @doc """
   Update the context data
   """
   def put_data(context, key, val) do
@@ -129,8 +144,17 @@ defmodule Kalevala.World.Room.Context do
   end
 
   defp send_events(context) do
-    Enum.each(context.events, fn {to_pid, event} ->
+    {events, delayed_events} =
+      Enum.split_with(context.events, fn event ->
+        match?(%Kalevala.Event{}, event)
+      end)
+
+    Enum.each(events, fn {to_pid, event} ->
       send(to_pid, event)
+    end)
+
+    Enum.each(delayed_events, fn {to_pid, delayed_event} ->
+      Process.send_after(to_pid, delayed_event, delayed_event.delay)
     end)
 
     context

--- a/lib/kalevala/world/room/context.ex
+++ b/lib/kalevala/world/room/context.ex
@@ -105,9 +105,18 @@ defmodule Kalevala.World.Room.Context do
 
   @doc """
   Broadcast an event to multiple characters in the room
+  Options:
+    - `to`: pre-filtered list of characters
+    - `except`: keyword or list of keywords
   """
   def broadcast(context, topic, data, opts \\ []) do
     recipients = Keyword.get(opts, :to, context.characters)
+
+    recipients =
+      case !is_list(recipients) do
+        true -> List.wrap(recipients)
+        false -> recipients
+      end
 
     recipients =
       case Keyword.get(opts, :except) do

--- a/lib/kalevala/world/room/context.ex
+++ b/lib/kalevala/world/room/context.ex
@@ -95,6 +95,14 @@ defmodule Kalevala.World.Room.Context do
   end
 
   @doc """
+  Update the context data
+  """
+  def put_data(context, key, val) do
+    data = Map.put(context.data, key, val)
+    Map.put(context, :data, data)
+  end
+
+  @doc """
   Handle context after processing an event
   """
   def handle_context(context) do

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -39,7 +39,7 @@ defmodule Kalevala.World.Room.Events do
           data: %Kalevala.Event.Movement.Notice{
             character: event.data.character,
             direction: event.data.direction,
-            data: event.data.data,
+            data: Map.delete(event.data.data, :character),
             reason: event.data.reason
           }
         }
@@ -286,7 +286,7 @@ defmodule Kalevala.World.Room.Movement do
         character: event.data.character,
         direction: event.data.direction,
         reason: event.data.reason,
-        data: event.data.data
+        data: Map.delete(event.data.data, :character)
       }
     }
 

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -285,7 +285,8 @@ defmodule Kalevala.World.Room.Movement do
       data: %Kalevala.Event.Movement.Notice{
         character: event.data.character,
         direction: event.data.direction,
-        reason: event.data.reason
+        reason: event.data.reason,
+        data: event.data.data
       }
     }
 

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -31,6 +31,7 @@ defmodule Kalevala.World.Room.Events do
     case event.data.room_id == state.data.id do
       true ->
         state = Movement.handle_event(state, event)
+        extra_data = with nil <- event.data.data, do: %{}
 
         event = %Kalevala.Event{
           acting_character: event.data.character,
@@ -39,7 +40,7 @@ defmodule Kalevala.World.Room.Events do
           data: %Kalevala.Event.Movement.Notice{
             character: event.data.character,
             direction: event.data.direction,
-            data: Map.delete(event.data.data, :character),
+            data: Map.delete(extra_data, :character),
             reason: event.data.reason
           }
         }
@@ -131,6 +132,11 @@ defmodule Kalevala.World.Room.Item do
     state
   end
 
+  def handle_drop_request({:proceed, event, item_instance, state, metadata})
+      when event.acting_character == %{type: zone} do
+    handle_spawn_request({:proceed, event, item_instance}, state, metadata)
+  end
+
   def handle_drop_request({:proceed, event, item_instance}, state, metadata) do
     character = event.acting_character
 
@@ -147,6 +153,10 @@ defmodule Kalevala.World.Room.Item do
     send(character.pid, event)
 
     add_item_instance(state, item_instance)
+  end
+
+  def handle_spawn_request({:proceed, event, item_instance}, state, metadata) do
+    zone = event.acting_character
   end
 
   @doc """

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -89,7 +89,11 @@ defmodule Kalevala.World.Room.Events do
       |> Handler.event(event)
       |> Context.handle_context()
 
-    private = Map.put(state.private, :item_instances, context.item_instances)
+    private =
+      state.private
+      |> Map.put(state.private, :characters, context.characters)
+      |> Map.put(state.private, :item_instances, context.item_instances)
+
     state = %{state | data: context.data, private: private}
 
     {:noreply, state}

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -32,6 +32,9 @@ defmodule Kalevala.World.Room.Events do
       true ->
         state = Movement.handle_event(state, event)
 
+        extra_data = with nil <- event.data.data, do: %{}
+        extra_data = Map.delete(extra_data, :character)
+
         event = %Kalevala.Event{
           acting_character: event.data.character,
           from_pid: event.from_pid,
@@ -39,7 +42,7 @@ defmodule Kalevala.World.Room.Events do
           data: %Kalevala.Event.Movement.Notice{
             character: event.data.character,
             direction: event.data.direction,
-            data: Map.delete(event.data.data, :character),
+            data: extra_data,
             reason: event.data.reason
           }
         }

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -91,8 +91,8 @@ defmodule Kalevala.World.Room.Events do
 
     private =
       state.private
-      |> Map.put(state.private, :characters, context.characters)
-      |> Map.put(state.private, :item_instances, context.item_instances)
+      |> Map.put(:characters, context.characters)
+      |> Map.put(:item_instances, context.item_instances)
 
     state = %{state | data: context.data, private: private}
 

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -31,7 +31,20 @@ defmodule Kalevala.World.Room.Events do
     case event.data.room_id == state.data.id do
       true ->
         state = Movement.handle_event(state, event)
-        {:noreply, state}
+
+        event = %Kalevala.Event{
+          acting_character: event.data.character,
+          from_pid: event.from_pid,
+          topic: Kalevala.Event.Movement.Notice,
+          data: %Kalevala.Event.Movement.Notice{
+            character: event.data.character,
+            direction: event.data.direction,
+            data: event.data.data,
+            reason: event.data.reason
+          }
+        }
+
+        handle_event(event, state)
 
       false ->
         Room.global_name(event.data.room_id)

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -89,7 +89,8 @@ defmodule Kalevala.World.Room.Events do
       |> Handler.event(event)
       |> Context.handle_context()
 
-    state = Map.put(state, :data, context.data)
+    private = Map.put(state.private, :item_instances, context.item_instances)
+    state = %{state | data: context.data, private: private}
 
     {:noreply, state}
   end

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -278,6 +278,9 @@ defmodule Kalevala.World.Room.Movement do
   Broadcast the event to characters in the room
   """
   def broadcast(state, event) do
+    data = event.data.data
+    data = if is_map(data), do: Map.delete(event.data.data, :character)
+
     event = %Kalevala.Event{
       acting_character: event.data.character,
       from_pid: event.from_pid,
@@ -286,7 +289,7 @@ defmodule Kalevala.World.Room.Movement do
         character: event.data.character,
         direction: event.data.direction,
         reason: event.data.reason,
-        data: Map.delete(event.data.data, :character)
+        data: data
       }
     }
 

--- a/lib/kalevala/world/room/events.ex
+++ b/lib/kalevala/world/room/events.ex
@@ -31,7 +31,6 @@ defmodule Kalevala.World.Room.Events do
     case event.data.room_id == state.data.id do
       true ->
         state = Movement.handle_event(state, event)
-        extra_data = with nil <- event.data.data, do: %{}
 
         event = %Kalevala.Event{
           acting_character: event.data.character,
@@ -40,7 +39,7 @@ defmodule Kalevala.World.Room.Events do
           data: %Kalevala.Event.Movement.Notice{
             character: event.data.character,
             direction: event.data.direction,
-            data: Map.delete(extra_data, :character),
+            data: Map.delete(event.data.data, :character),
             reason: event.data.reason
           }
         }
@@ -132,11 +131,6 @@ defmodule Kalevala.World.Room.Item do
     state
   end
 
-  def handle_drop_request({:proceed, event, item_instance, state, metadata})
-      when event.acting_character == %{type: zone} do
-    handle_spawn_request({:proceed, event, item_instance}, state, metadata)
-  end
-
   def handle_drop_request({:proceed, event, item_instance}, state, metadata) do
     character = event.acting_character
 
@@ -153,10 +147,6 @@ defmodule Kalevala.World.Room.Item do
     send(character.pid, event)
 
     add_item_instance(state, item_instance)
-  end
-
-  def handle_spawn_request({:proceed, event, item_instance}, state, metadata) do
-    zone = event.acting_character
   end
 
   @doc """

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -9,6 +9,9 @@ defmodule Kalevala.World.Zone do
 
   alias Kalevala.Event
   alias Kalevala.World.Zone.Movement
+  alias Kalevala.World.Zone.Handler
+  alias Kalevala.World.Zone.Callbacks
+  alias Kalevala.World.Zone.Context
 
   @type t() :: map()
 
@@ -65,6 +68,36 @@ defmodule Kalevala.World.Zone do
 
     {:noreply, state}
   end
+
+  @impl true
+  def handle_info(event = %Event{}, state) do
+    context =
+      state
+      |> Handler.event(event)
+      |> Context.handle_context()
+
+    state = Map.put(state, :data, context.data)
+
+    {:noreply, state}
+  end
+end
+
+defmodule Kalevala.World.Zone.Handler do
+  @moduledoc false
+
+  alias Kalevala.World.Zone.Callbacks
+  alias Kalevala.World.Zone.Context
+
+  def event(state, event) do
+    Callbacks.event(state.data, Context.new(state), event)
+  end
+end
+
+defprotocol Kalevala.World.Zone.Callbacks do
+  @doc """
+  Callback for when a new event is received
+  """
+  def event(zone, context, event)
 end
 
 defmodule Kalevala.World.BasicZone do

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -101,7 +101,7 @@ defprotocol Kalevala.World.Zone.Callbacks do
   def init(zone)
 
   @doc """
-  Called after the room process is started
+  Called after the zone process is started
 
   Directly after `init` is completed.
   """

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -45,7 +45,7 @@ defmodule Kalevala.World.Zone do
     Logger.info("Zone starting - #{options.zone.id}")
 
     config = options.config
-    zone = config.callback_module.init(options.zone)
+    zone = Callbacks.init(options.zone)
 
     state = %{
       data: zone,
@@ -94,6 +94,11 @@ defmodule Kalevala.World.Zone.Handler do
 end
 
 defprotocol Kalevala.World.Zone.Callbacks do
+  @doc """
+  Called when the zone is initializing
+  """
+  def init(zone)
+
   @doc """
   Callback for when a new event is received
   """

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -53,7 +53,8 @@ defmodule Kalevala.World.Zone do
 
   @impl true
   def handle_continue(:initialized, state) do
-    state = Callbacks.initialized(state.data)
+    data = Callbacks.initialized(state.data)
+    state = %{state | data: data}
     {:noreply, state}
   end
 

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -16,11 +16,6 @@ defmodule Kalevala.World.Zone do
   @type t() :: map()
 
   @doc """
-  Called when the zone is initializing
-  """
-  @callback init(zone :: t()) :: t()
-
-  @doc """
   Replace internal zone state
   """
   def update(pid, zone) do

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -48,7 +48,13 @@ defmodule Kalevala.World.Zone do
       callback_module: config.callback_module
     }
 
-    {:ok, state}
+    {:ok, state, {:continue, :initialized}}
+  end
+
+  @impl true
+  def handle_continue(:initialized, state) do
+    Callbacks.initialized(state.data)
+    {:noreply, state}
   end
 
   @impl true
@@ -93,6 +99,13 @@ defprotocol Kalevala.World.Zone.Callbacks do
   Called when the zone is initializing
   """
   def init(zone)
+
+  @doc """
+  Called after the room process is started
+
+  Directly after `init` is completed.
+  """
+  def initialized(zone)
 
   @doc """
   Callback for when a new event is received

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -82,6 +82,13 @@ defmodule Kalevala.World.Zone do
 
     {:noreply, state}
   end
+
+  @impl true
+  def handle_info(event = %Event.Delayed{}, state) do
+    event
+    |> Event.Delayed.to_event()
+    |> handle_info(state)
+  end
 end
 
 defmodule Kalevala.World.Zone.Handler do

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -85,9 +85,16 @@ defmodule Kalevala.World.Zone do
 
   @impl true
   def handle_info(event = %Event.Delayed{}, state) do
-    event
-    |> Event.Delayed.to_event()
-    |> handle_info(state)
+    event = Event.Delayed.to_event(event)
+
+    context =
+      state
+      |> Handler.event(event)
+      |> Context.handle_context()
+
+    state = Map.put(state, :data, context.data)
+
+    {:noreply, state}
   end
 end
 

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -53,7 +53,7 @@ defmodule Kalevala.World.Zone do
 
   @impl true
   def handle_continue(:initialized, state) do
-    Callbacks.initialized(state.data)
+    state = Callbacks.initialized(state.data)
     {:noreply, state}
   end
 

--- a/lib/kalevala/world/zone/context.ex
+++ b/lib/kalevala/world/zone/context.ex
@@ -115,7 +115,7 @@ defmodule Kalevala.World.Zone.Context do
 
   defp send_events(context) do
     {events, delayed_events} =
-      Enum.split_with(context.events, fn event ->
+      Enum.split_with(context.events, fn {_, event} ->
         match?(%Kalevala.Event{}, event)
       end)
 

--- a/lib/kalevala/world/zone/context.ex
+++ b/lib/kalevala/world/zone/context.ex
@@ -82,6 +82,21 @@ defmodule Kalevala.World.Zone.Context do
   end
 
   @doc """
+  Send an event to a pid on a delay
+  """
+
+  def delay_event(context, delay, to_pid, topic, data) do
+    event = %Kalevala.Event.Delayed{
+      delay: delay,
+      from_pid: self(),
+      topic: topic,
+      data: data
+    }
+
+    Map.put(context, :events, context.events ++ [{self(), event}])
+  end
+
+  @doc """
   Update the context data
   """
   def put_data(context, key, val) do
@@ -99,8 +114,17 @@ defmodule Kalevala.World.Zone.Context do
   end
 
   defp send_events(context) do
-    Enum.each(context.events, fn {to_pid, event} ->
+    {events, delayed_events} =
+      Enum.split_with(context.events, fn event ->
+        match?(%Kalevala.Event{}, event)
+      end)
+
+    Enum.each(events, fn {to_pid, event} ->
       send(to_pid, event)
+    end)
+
+    Enum.each(delayed_events, fn {to_pid, delayed_event} ->
+      Process.send_after(to_pid, delayed_event, delayed_event.delay)
     end)
 
     context

--- a/lib/kalevala/world/zone/context.ex
+++ b/lib/kalevala/world/zone/context.ex
@@ -1,0 +1,54 @@
+defmodule Kalevala.World.Zone.Context do
+  @moduledoc """
+  Context for performing work for an event in a room
+  """
+
+  @type t() :: %__MODULE__{}
+
+  defstruct [:data, events: []]
+
+  @doc """
+  Create a new context struct from room state
+  """
+  def new(state) do
+    %__MODULE__{
+      data: state.data
+    }
+  end
+
+  @doc """
+  Send an event back to a pid
+  """
+  def event(context, to_pid, from_pid, topic, data) do
+    event = %Kalevala.Event{
+      from_pid: from_pid,
+      topic: topic,
+      data: data
+    }
+
+    Map.put(context, :events, context.events ++ [{to_pid, event}])
+  end
+
+  @doc """
+  Update the context data
+  """
+  def put_data(context, key, val) do
+    data = Map.put(context.data, key, val)
+    Map.put(context, :data, data)
+  end
+
+  @doc """
+  Handle context after processing an event
+  """
+  def handle_context(context) do
+    send_events(context)
+  end
+
+  defp send_events(context) do
+    Enum.each(context.events, fn {to_pid, event} ->
+      send(to_pid, event)
+    end)
+
+    context
+  end
+end

--- a/lib/kalevala/world/zone/context.ex
+++ b/lib/kalevala/world/zone/context.ex
@@ -7,7 +7,7 @@ defmodule Kalevala.World.Zone.Context do
 
   @type t() :: %__MODULE__{}
 
-  defstruct [:data, events: [], output: []]
+  defstruct [:data, events: [], output: [], assigns: %{}]
 
   @doc """
   Create a new context struct from room state

--- a/lib/kalevala/world/zone/context.ex
+++ b/lib/kalevala/world/zone/context.ex
@@ -3,9 +3,11 @@ defmodule Kalevala.World.Zone.Context do
   Context for performing work for an event in a room
   """
 
+  alias Kalevala.Event
+
   @type t() :: %__MODULE__{}
 
-  defstruct [:data, events: []]
+  defstruct [:data, events: [], output: []]
 
   @doc """
   Create a new context struct from room state
@@ -14,6 +16,56 @@ defmodule Kalevala.World.Zone.Context do
     %__MODULE__{
       data: state.data
     }
+  end
+
+  defp push(context, to_pid, event = %Kalevala.Character.Conn.Event{}, _newline) do
+    Map.put(context, :output, context.output ++ [{to_pid, event}])
+  end
+
+  defp push(context, to_pid, event = %Kalevala.Character.Conn.EventText{}, newline) do
+    text = %Kalevala.Character.Conn.Text{
+      data: event.text,
+      newline: newline
+    }
+
+    event = %{event | text: text}
+
+    Map.put(context, :output, context.output ++ [{to_pid, event}])
+  end
+
+  defp push(context, to_pid, data, newline) do
+    text = %Kalevala.Character.Conn.Text{
+      data: data,
+      newline: newline
+    }
+
+    Map.put(context, :output, context.output ++ [{to_pid, text}])
+  end
+
+  @doc """
+  Render text back to a pid
+  """
+  def render(context, to_pid, view, template, assigns \\ %{}) do
+    assigns = Map.merge(context.assigns, assigns)
+    data = view.render(template, assigns)
+    push(context, to_pid, data, false)
+  end
+
+  @doc """
+  Render a prompt back to a pid
+  """
+  def prompt(context, to_pid, view, template, assigns) do
+    assigns = Map.merge(context.assigns, assigns)
+    data = view.render(template, assigns)
+    push(context, to_pid, data, true)
+  end
+
+  @doc """
+  Add to the assignment map on the context
+  """
+  def assign(context, key, value) do
+    assigns = Map.put(context.assigns, key, value)
+    Map.put(context, :assigns, assigns)
   end
 
   @doc """
@@ -41,12 +93,31 @@ defmodule Kalevala.World.Zone.Context do
   Handle context after processing an event
   """
   def handle_context(context) do
-    send_events(context)
+    context
+    |> send_events()
+    |> send_output()
   end
 
   defp send_events(context) do
     Enum.each(context.events, fn {to_pid, event} ->
       send(to_pid, event)
+    end)
+
+    context
+  end
+
+  defp send_output(context) do
+    context.output
+    |> Enum.group_by(
+      fn {to_pid, _text} ->
+        to_pid
+      end,
+      fn {_to_pid, text} ->
+        text
+      end
+    )
+    |> Enum.each(fn {to_pid, text} ->
+      send(to_pid, %Event.Display{output: text})
     end)
 
     context


### PR DESCRIPTION
Contexts have no method to update Context.data from what I can tell even though any changes to Context.data are persisted. This will allow changes to data to be made. (e.g. for updating door states, etc.).